### PR TITLE
Correcting typo in Digital Passport title

### DIFF
--- a/website/docs/specification/DigitalProductPassport.md
+++ b/website/docs/specification/DigitalProductPassport.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 5
-title: Digitial Product Passport
+title: Digital Product Passport
 ---
 
 import Disclaimer from '../\_disclaimer.mdx';


### PR DESCRIPTION
Correcting title from "Digitial" to "Digital"